### PR TITLE
Refactor core Ruby module API

### DIFF
--- a/lib/seam.rb
+++ b/lib/seam.rb
@@ -29,8 +29,4 @@ module Seam
   def self.lts_version
     Seam::LTS_VERSION
   end
-
-  def lts_version
-    Seam::LTS_VERSION
-  end
 end

--- a/lib/seam.rb
+++ b/lib/seam.rb
@@ -5,7 +5,7 @@ require_relative "seam/lts_version"
 require_relative "seam/default_endpoint"
 require_relative "seam/request"
 require_relative "seam/logger"
-require_relative "seam/client"
+require_relative "seam/http"
 require_relative "seam/base_client"
 require_relative "seam/base_resource"
 require_relative "seam/errors"
@@ -14,4 +14,23 @@ require_relative "seam/routes/resources/index"
 require_relative "seam/routes/clients/index"
 
 module Seam
+  def self.new(**args)
+    Http.new(**args)
+  end
+
+  def self.from_api_key(api_key, endpoint: nil, wait_for_action_attempt: false, debug: false)
+    new(api_key: api_key, endpoint: endpoint, wait_for_action_attempt: wait_for_action_attempt, debug: debug)
+  end
+
+  def self.from_personal_access_token(personal_access_token, workspace_id, endpoint: nil, wait_for_action_attempt: false, debug: false)
+    new(personal_access_token: personal_access_token, workspace_id: workspace_id, endpoint: endpoint, wait_for_action_attempt: wait_for_action_attempt, debug: debug)
+  end
+
+  def self.lts_version
+    Seam::LTS_VERSION
+  end
+
+  def lts_version
+    Seam::LTS_VERSION
+  end
 end

--- a/lib/seam/http.rb
+++ b/lib/seam/http.rb
@@ -4,10 +4,10 @@ require_relative "parse_options"
 require_relative "routes/routes"
 
 module Seam
-  class Client
+  class Http
     include Seam::Routes
 
-    attr_accessor :wait_for_action_attempt, :defaults
+    attr_accessor :defaults
 
     def initialize(api_key: nil, personal_access_token: nil, workspace_id: nil, endpoint: nil,
       wait_for_action_attempt: true, debug: false)
@@ -17,22 +17,6 @@ module Seam
       @debug = debug
       @wait_for_action_attempt = wait_for_action_attempt
       @defaults = {"wait_for_action_attempt" => wait_for_action_attempt}
-    end
-
-    def self.from_api_key(api_key, endpoint: nil, wait_for_action_attempt: false, debug: false)
-      new(api_key: api_key, endpoint: endpoint, wait_for_action_attempt: wait_for_action_attempt, debug: debug)
-    end
-
-    def self.from_personal_access_token(personal_access_token, workspace_id, endpoint: nil, wait_for_action_attempt: false, debug: false)
-      new(personal_access_token: personal_access_token, workspace_id: workspace_id, endpoint: endpoint, wait_for_action_attempt: wait_for_action_attempt, debug: debug)
-    end
-
-    def self.lts_version
-      Seam::LTS_VERSION
-    end
-
-    def lts_version
-      Seam::LTS_VERSION
     end
 
     def request_seam_object(method, path, klass, inner_object, config = {})

--- a/lib/seam/http.rb
+++ b/lib/seam/http.rb
@@ -19,6 +19,10 @@ module Seam
       @defaults = Seam::DeepHashAccessor.new({"wait_for_action_attempt" => wait_for_action_attempt})
     end
 
+    def lts_version
+      Seam::LTS_VERSION
+    end
+
     def request_seam_object(method, path, klass, inner_object, config = {})
       response = request_seam(method, path, config)
 

--- a/lib/seam/http.rb
+++ b/lib/seam/http.rb
@@ -16,7 +16,7 @@ module Seam
       @auth_headers = options[:auth_headers]
       @debug = debug
       @wait_for_action_attempt = wait_for_action_attempt
-      @defaults = {"wait_for_action_attempt" => wait_for_action_attempt}
+      @defaults = Seam::DeepHashAccessor.new({"wait_for_action_attempt" => wait_for_action_attempt})
     end
 
     def request_seam_object(method, path, klass, inner_object, config = {})

--- a/lib/seam/utils/action_attempt_utils.rb
+++ b/lib/seam/utils/action_attempt_utils.rb
@@ -4,7 +4,7 @@ module Seam
   module Utils
     module ActionAttemptUtils
       def self.decide_and_wait(action_attempt, client, wait_for_action_attempt)
-        wait_decision = wait_for_action_attempt.nil? ? client.defaults["wait_for_action_attempt"] : wait_for_action_attempt
+        wait_decision = wait_for_action_attempt.nil? ? client.defaults.wait_for_action_attempt : wait_for_action_attempt
 
         if wait_decision == true
           wait_until_finished(action_attempt, client)

--- a/spec/clients/access_codes_spec.rb
+++ b/spec/clients/access_codes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::AccessCodes do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#list" do
     let(:access_code_id) { "123" }

--- a/spec/clients/action_attempts_spec.rb
+++ b/spec/clients/action_attempts_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::AccessCodes do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#get" do
     let(:action_attempt_id) { "action_attempt_id_1234" }

--- a/spec/clients/connect_webviews_spec.rb
+++ b/spec/clients/connect_webviews_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::ConnectWebviews do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#list" do
     let(:connect_webview_hash) { {connect_webview_id: "123"} }

--- a/spec/clients/connected_accounts_spec.rb
+++ b/spec/clients/connected_accounts_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::ConnectedAccounts do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
   let(:connected_account_id) { "connected_account_id_1234" }
 
   describe "#get" do

--- a/spec/clients/devices_spec.rb
+++ b/spec/clients/devices_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::Devices do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#list" do
     let(:device_hash) { {device_id: "123"} }

--- a/spec/clients/events_spec.rb
+++ b/spec/clients/events_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::Events do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#list" do
     let(:event_hash) { {event_id: "1234"} }

--- a/spec/clients/locks_spec.rb
+++ b/spec/clients/locks_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::Locks do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#list" do
     let(:locks_hash) { {device_id: "123"} }

--- a/spec/clients/unmanaged_access_codes_spec.rb
+++ b/spec/clients/unmanaged_access_codes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::AccessCodesUnmanaged do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#get" do
     let(:access_code_id) { "123" }

--- a/spec/clients/unmanaged_devices_spec.rb
+++ b/spec/clients/unmanaged_devices_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::DevicesUnmanaged do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#get" do
     context "'device_id' param" do

--- a/spec/clients/workspaces_spec.rb
+++ b/spec/clients/workspaces_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::Clients::Workspaces do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#list" do
     let(:workspace_hash) { {workspace_id: "123"} }

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Seam::Client do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+RSpec.describe Seam::Http do
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "Exceptions" do
     describe "400" do

--- a/spec/resources/action_attempt_spec.rb
+++ b/spec/resources/action_attempt_spec.rb
@@ -3,7 +3,7 @@
 require "seam/utils/action_attempt_utils"
 
 RSpec.describe Seam::Utils::ActionAttemptUtils do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
   let(:action_attempt_id) { "action_attempt_id_1234" }
   let(:finished_status) { "finished" }
   let(:action_attempt_hash) do
@@ -28,14 +28,15 @@ RSpec.describe Seam::Utils::ActionAttemptUtils do
       let(:wait_options) { {timeout: 10, polling_interval: 1} }
 
       it "calls wait_until_finished with options" do
-        expect(described_class).to receive(:wait_until_finished).with(action_attempt, client, timeout: 10, polling_interval: 1)
+        expect(described_class).to receive(:wait_until_finished).with(action_attempt, client, timeout: 10,
+          polling_interval: 1)
         described_class.decide_and_wait(action_attempt, client, wait_options)
       end
     end
 
     context "when wait_for_action_attempt is nil" do
       it "uses the client's actual default wait_for_action_attempt value" do
-        client_default = client.defaults["wait_for_action_attempt"]
+        client_default = client.defaults.wait_for_action_attempt
 
         if client_default
           expect(described_class).to receive(:wait_until_finished).with(action_attempt, client)

--- a/spec/resources/base_resource_spec.rb
+++ b/spec/resources/base_resource_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Seam::BaseResource do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
   let(:device_hash) do
     {
       device_id: "device_id_1234",

--- a/spec/seam_client/api_key_spec.rb
+++ b/spec/seam_client/api_key_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Seam::Client do
-  let(:client) { Seam::Client.new(api_key: "seam_some_api_key") }
+RSpec.describe Seam::Http do
+  let(:client) { Seam.new(api_key: "seam_some_api_key") }
   let(:device_hash) { {device_id: "123"} }
 
   describe "#from_api_key" do
@@ -23,19 +23,19 @@ RSpec.describe Seam::Client do
   describe "#api_key_format" do
     it "checks api key format" do
       expect do
-        Seam::Client.from_api_key("some-invalid-key-format")
+        Seam.from_api_key("some-invalid-key-format")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
 
       expect do
-        Seam::Client.from_api_key("ey")
+        Seam.from_api_key("ey")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /JWT/)
 
       expect do
-        Seam::Client.from_api_key("seam_cst_token")
+        Seam.from_api_key("seam_cst_token")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Client Session Token/)
 
       expect do
-        Seam::Client.from_api_key("seam_at")
+        Seam.from_api_key("seam_at")
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Access Token/)
     end
   end

--- a/spec/seam_client/env_spec.rb
+++ b/spec/seam_client/env_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Seam::Client do
+RSpec.describe Seam::Http do
   before(:each) do
     cleanup_env
   end
@@ -20,7 +20,7 @@ RSpec.describe Seam::Client do
   describe "#initialize" do
     it "uses SEAM_API_KEY environment variable" do
       ENV["SEAM_API_KEY"] = "seam_some_api_key"
-      seam = Seam::Client.new
+      seam = Seam.new
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
       devices = seam.devices.list
@@ -29,7 +29,7 @@ RSpec.describe Seam::Client do
 
     it "api_key option overrides environment variables" do
       ENV["SEAM_API_KEY"] = "some-invalid-api-key-1"
-      seam = Seam::Client.new(api_key: "seam_some_api_key")
+      seam = Seam.new(api_key: "seam_some_api_key")
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
       devices = seam.devices.list
@@ -37,15 +37,15 @@ RSpec.describe Seam::Client do
     end
 
     it "requires api_key when passed no argument" do
-      expect {
-        Seam::Client.new
-      }.to raise_error(SeamOptions::SeamInvalidOptionsError, /api_key/)
+      expect do
+        Seam.new
+      end.to raise_error(SeamOptions::SeamInvalidOptionsError, /api_key/)
     end
 
     it "uses SEAM_ENDPOINT environment variable first" do
       ENV["SEAM_API_URL"] = "https://example.com"
       ENV["SEAM_ENDPOINT"] = Seam::DEFAULT_ENDPOINT
-      seam = Seam::Client.new(api_key: "seam_some_api_key")
+      seam = Seam.new(api_key: "seam_some_api_key")
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
       devices = seam.devices.list
@@ -54,7 +54,7 @@ RSpec.describe Seam::Client do
 
     it "uses SEAM_API_URL environment variable as fallback" do
       ENV["SEAM_API_URL"] = Seam::DEFAULT_ENDPOINT
-      seam = Seam::Client.new(api_key: "seam_some_api_key")
+      seam = Seam.new(api_key: "seam_some_api_key")
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
       devices = seam.devices.list
@@ -64,7 +64,7 @@ RSpec.describe Seam::Client do
     it "endpoint option overrides environment variables" do
       ENV["SEAM_API_URL"] = "https://example.com"
       ENV["SEAM_ENDPOINT"] = "https://example.com"
-      seam = Seam::Client.new(api_key: "seam_some_api_key", endpoint: Seam::DEFAULT_ENDPOINT)
+      seam = Seam.new(api_key: "seam_some_api_key", endpoint: Seam::DEFAULT_ENDPOINT)
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
       devices = seam.devices.list
@@ -74,7 +74,7 @@ RSpec.describe Seam::Client do
     it "uses SEAM_ENDPOINT environment variable with from_api_key" do
       ENV["SEAM_API_URL"] = "https://example.com"
       ENV["SEAM_ENDPOINT"] = Seam::DEFAULT_ENDPOINT
-      seam = Seam::Client.from_api_key("seam_some_api_key")
+      seam = Seam.from_api_key("seam_some_api_key")
 
       stub_seam_request(:post, "/devices/list", {devices: [device_hash]})
       devices = seam.devices.list
@@ -84,7 +84,7 @@ RSpec.describe Seam::Client do
     it "ignores SEAM_API_KEY environment variable with personal access token" do
       ENV["SEAM_API_KEY"] = "seam_some_api_key"
 
-      seam = Seam::Client.from_personal_access_token(
+      seam = Seam.from_personal_access_token(
         "seam_at1_token",
         "workspace_123"
       )

--- a/spec/seam_client/http_error_spec.rb
+++ b/spec/seam_client/http_error_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Seam::Errors::SeamHttpInvalidInputError do
   let(:api_key) { "seam_apikey1_token" }
-  let(:client) { Seam::Client.new(api_key: api_key) }
+  let(:client) { Seam.new(api_key: api_key) }
 
   describe "handling invalid input errors" do
     let(:error_response) do
@@ -26,9 +26,9 @@ RSpec.describe Seam::Errors::SeamHttpInvalidInputError do
         req.body.source == {device_ids: 123}.to_json
       end
 
-      expect {
+      expect do
         client.devices.list(device_ids: 123)
-      }.to raise_error(Seam::Errors::SeamHttpInvalidInputError) do |error|
+      end.to raise_error(Seam::Errors::SeamHttpInvalidInputError) do |error|
         expect(error.code).to eq("invalid_input")
         expect(error.status_code).to eq(400)
         expect(error.get_validation_error_messages("device_ids")).to eq(["Expected array, received number"])
@@ -44,8 +44,8 @@ RSpec.describe Seam::Errors::SeamHttpInvalidInputError do
 
       begin
         client.devices.list(device_ids: 123)
-      rescue Seam::Errors::SeamHttpInvalidInputError => error
-        expect(error.get_validation_error_messages("non_existent_field")).to eq([])
+      rescue Seam::Errors::SeamHttpInvalidInputError => e
+        expect(e.get_validation_error_messages("non_existent_field")).to eq([])
       end
     end
   end

--- a/spec/seam_client/init_seam_spec.rb
+++ b/spec/seam_client/init_seam_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe Seam::Client do
-  let(:seam) { Seam::Client.new(api_key: "seam_some_api_key") }
+RSpec.describe Seam::Http do
+  let(:seam) { Seam.new(api_key: "seam_some_api_key") }
 
   describe "#initialize" do
     it "initializes Seam with fixture" do
+      expect(Seam.lts_version).not_to be_nil
       expect(seam.lts_version).not_to be_nil
-      expect(seam.wait_for_action_attempt).to be true
+      expect(seam.defaults.wait_for_action_attempt).to be true
     end
   end
 end

--- a/spec/seam_client/personal_access_token_spec.rb
+++ b/spec/seam_client/personal_access_token_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-RSpec.describe Seam::Client do
+RSpec.describe Seam::Http do
   let(:workspace_id) { "e4203e37-e569-4a5a-bfb7-e3e8de66161d" }
 
   describe "#from_personal_access_token" do
     it "raises error for invalid personal access token formats" do
       expect do
-        Seam::Client.from_personal_access_token("some-invalid-key-format", workspace_id)
+        Seam.from_personal_access_token("some-invalid-key-format", workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
 
       expect do
-        Seam::Client.from_personal_access_token("seam_apikey_token", workspace_id)
+        Seam.from_personal_access_token("seam_apikey_token", workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Unknown/)
 
       expect do
-        Seam::Client.from_personal_access_token("seam_cst", workspace_id)
+        Seam.from_personal_access_token("seam_cst", workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /Client Session Token/)
 
       expect do
-        Seam::Client.from_personal_access_token("ey", workspace_id)
+        Seam.from_personal_access_token("ey", workspace_id)
       end.to raise_error(SeamAuth::SeamInvalidTokenError, /JWT/)
     end
   end

--- a/spec/seam_client/request_spec.rb
+++ b/spec/seam_client/request_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Seam::Client do
-  let(:seam) { Seam::Client.new(api_key: "seam_some_api_key") }
+RSpec.describe Seam::Http do
+  let(:seam) { Seam.new(api_key: "seam_some_api_key") }
   let(:request_id) { "request_id_1234" }
 
   describe "#request_seam" do
@@ -33,11 +33,14 @@ RSpec.describe Seam::Client do
 
       before do
         stub_request(:post, "#{Seam::DEFAULT_ENDPOINT}/devices/get")
-          .to_return(status: error_status, body: error_response, headers: {"Content-Type" => "application/json", "seam-request-id" => request_id})
+          .to_return(status: error_status, body: error_response, headers: {"Content-Type" => "application/json",
+                                                                           "seam-request-id" => request_id})
       end
 
       it "raises SeamHttpInvalidInputError" do
-        expect { seam.devices.get(device_id: "invalid_device_id") }.to raise_error(Seam::Errors::SeamHttpInvalidInputError) do |error|
+        expect do
+          seam.devices.get(device_id: "invalid_device_id")
+        end.to raise_error(Seam::Errors::SeamHttpInvalidInputError) do |error|
           expect(error.message).to eq(error_message)
           expect(error.status_code).to eq(error_status)
           expect(error.request_id).to eq(request_id)
@@ -60,7 +63,8 @@ RSpec.describe Seam::Client do
 
       before do
         stub_request(:post, "#{Seam::DEFAULT_ENDPOINT}/devices/list")
-          .to_return(status: error_status, body: error_response, headers: {"Content-Type" => "application/json", "seam-request-id" => request_id})
+          .to_return(status: error_status, body: error_response, headers: {"Content-Type" => "application/json",
+                                                                           "seam-request-id" => request_id})
       end
 
       it "raises SeamHttpApiError with the correct details" do

--- a/spec/seam_client/wait_for_action_attepmt_spec.rb
+++ b/spec/seam_client/wait_for_action_attepmt_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe Seam::Client do
+RSpec.describe Seam::Http do
   let(:api_key) { "seam_apikey1_token" }
   let(:device_id) { "august_device_1" }
 
@@ -114,12 +114,12 @@ RSpec.describe Seam::Client do
       stub_seam_request(:post, "/action_attempts/get", pending_response)
         .with { |req| req.body.source == {action_attempt_id: "1234"}.to_json }
 
-      expect {
+      expect do
         client.action_attempts.get(
           action_attempt_id: action_attempt.action_attempt_id,
           wait_for_action_attempt: {timeout: 0.1}
         )
-      }.to raise_error(Seam::Errors::SeamActionAttemptTimeoutError) do |error|
+      end.to raise_error(Seam::Errors::SeamActionAttemptTimeoutError) do |error|
         expect(error.action_attempt.action_attempt_id).to eq(action_attempt.action_attempt_id)
         expect(error.action_attempt.status).to eq(action_attempt.status)
       end
@@ -137,12 +137,12 @@ RSpec.describe Seam::Client do
       stub_seam_request(:post, "/action_attempts/get", error_response)
         .with { |req| req.body.source == {action_attempt_id: "1234"}.to_json }
 
-      expect {
+      expect do
         client.action_attempts.get(
           action_attempt_id: action_attempt.action_attempt_id,
           wait_for_action_attempt: true
         )
-      }.to raise_error(Seam::Errors::SeamActionAttemptFailedError) do |error|
+      end.to raise_error(Seam::Errors::SeamActionAttemptFailedError) do |error|
         expect(error.message).to include("Failed")
         expect(error.action_attempt.action_attempt_id).to eq(action_attempt.action_attempt_id)
         expect(error.action_attempt.status).to eq("error")
@@ -162,12 +162,12 @@ RSpec.describe Seam::Client do
       stub_seam_request(:post, "/action_attempts/get", pending_response)
         .with { |req| req.body.source == {action_attempt_id: "1234"}.to_json }
 
-      expect {
+      expect do
         client.action_attempts.get(
           action_attempt_id: action_attempt.action_attempt_id,
           wait_for_action_attempt: {timeout: 0.5, polling_interval: 3}
         )
-      }.to raise_error(Seam::Errors::SeamActionAttemptTimeoutError) do |error|
+      end.to raise_error(Seam::Errors::SeamActionAttemptTimeoutError) do |error|
         expect(error.action_attempt.action_attempt_id).to eq(action_attempt.action_attempt_id)
         expect(error.action_attempt.status).to eq(action_attempt.status)
       end


### PR DESCRIPTION
- **Rename Client to Http, use it in Seam module constructor and move factory methods to Seam**
- **FIx tests**
- **Allow accessing defaults with dot notation**
- **Move lts_version method to Http class**
